### PR TITLE
Json Serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-
+//
 group "org.polypheny"
 
 
@@ -17,7 +17,7 @@ buildscript {
         }
     }
     dependencies {
-		// Shadowing; used to make a fat jar (https://github.com/johnrengelman/shadow)
+        // Shadowing; used to make a fat jar (https://github.com/johnrengelman/shadow)
         classpath group: "com.github.jengelman.gradle.plugins", name: "shadow", version: "5.2.0"
         // Lombok (https://plugins.gradle.org/plugin/io.freefair.lombok)
         classpath group: "io.freefair.gradle", name: "lombok-plugin", version: "4.1.6"
@@ -26,6 +26,8 @@ buildscript {
 
 
 repositories {
+    mavenCentral()
+    jcenter()
     maven {
         // DBIS Nexus
         url "https://dbis-nexus.dmi.unibas.ch/repository/maven2/"
@@ -33,8 +35,6 @@ repositories {
     maven {
         url "https://clojars.org/repo/"
     }
-    mavenCentral()
-    jcenter()
 }
 
 
@@ -49,10 +49,19 @@ tasks.withType(JavaCompile) {
     options.encoding = "UTF-8"
 }
 
-compileJava   {
+compileJava {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 }
+
+
+configurations.all {
+    // check for updates every build
+    resolutionStrategy{
+        cacheChangingModulesFor 0, 'seconds'
+    }
+}
+
 
 def avaticaVersion = '1.16.0-POLYPHENY-SNAPSHOT'
 
@@ -74,11 +83,10 @@ dependencies {
 }
 
 
-
 sourceSets {
     main {
         java {
-            srcDirs = ["src/main/java","build/generated-sources"]
+            srcDirs = ["src/main/java", "build/generated-sources"]
             outputDir = file(project.buildDir.absolutePath + "/classes")
         }
         resources {
@@ -97,7 +105,6 @@ sourceSets {
         output.resourcesDir = file(project.buildDir.absolutePath + "/test-classes")
     }
 }
-
 
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,11 @@ configurations.all {
     resolutionStrategy.cacheChangingModulesFor 0, "seconds"
 }
 
+def avaticaVersion = '1.16.0-POLYPHENY-SNAPSHOT'
 
 dependencies {
     ////// APACHE CALCITE AVATICA
-    compile group: "org.apache.calcite.avatica", name: "avatica-core", version: "1.16.0-POLYPHENY-SNAPSHOT"  // License: Apache 2.0
+    compile group: "org.apache.calcite.avatica", name: "avatica-core", version: avaticaVersion  // License: Apache 2.0
 
     ////// APACHE COMMONS LANG
     compile group: "org.apache.commons", name: "commons-lang3", version: "3.7"
@@ -75,6 +76,7 @@ dependencies {
     // --- Test Compile ---
     testCompile group: "junit", name: "junit", version: "4.12"
     testCompile group: "org.testng", name: "testng", version: "6.10"
+    testCompile group: 'org.apache.calcite.avatica', name: 'avatica-server', version: avaticaVersion
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ buildscript {
 
 
 repositories {
-    mavenLocal()
     maven {
         // DBIS Nexus
         url "https://dbis-nexus.dmi.unibas.ch/repository/maven2/"
@@ -53,11 +52,6 @@ tasks.withType(JavaCompile) {
 compileJava   {
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
-}
-
-configurations.all {
-    // check for updates every build
-    resolutionStrategy.cacheChangingModulesFor 0, "seconds"
 }
 
 def avaticaVersion = '1.16.0-POLYPHENY-SNAPSHOT'

--- a/src/main/java/org/polypheny/jdbc/Driver.java
+++ b/src/main/java/org/polypheny/jdbc/Driver.java
@@ -24,6 +24,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.StringTokenizer;
 import lombok.extern.slf4j.Slf4j;
@@ -34,8 +35,10 @@ import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.UnregisteredDriver;
 import org.apache.calcite.avatica.remote.AvaticaHttpClient;
 import org.apache.calcite.avatica.remote.AvaticaHttpClientFactory;
+import org.apache.calcite.avatica.remote.Driver.Serialization;
 import org.apache.calcite.avatica.remote.ProtobufTranslationImpl;
 import org.apache.calcite.avatica.remote.RemoteProtobufService;
+import org.apache.calcite.avatica.remote.RemoteService;
 import org.apache.calcite.avatica.remote.Service;
 import org.apache.calcite.avatica.remote.Service.OpenConnectionRequest;
 import org.apache.calcite.avatica.remote.Service.OpenConnectionResponse;
@@ -44,20 +47,27 @@ import org.apache.calcite.avatica.remote.Service.OpenConnectionResponse;
 @Slf4j
 public class Driver extends UnregisteredDriver {
 
+    public static final String DRIVER_URL_SCHEMA = "jdbc:polypheny:";
+    @Deprecated
+    public static final String URL_SCHEMA = DRIVER_URL_SCHEMA;
+
     public static final String DEFAULT_HOST = "localhost";
     public static final int DEFAULT_PORT = 20591;
-    public static final String URL_SCHEMA = "jdbc:polypheny:";
-    static final String PROPERTY_USERNAME_KEY = "user";
+    public static final String DEFAULT_TRANSPORT_SCHEMA = "http:";
+    public static final String DEFAULT_SERIALIZATION = Serialization.PROTOBUF.name();
+
+    public static final String PROPERTY_USERNAME_KEY = "user";
     @java.lang.SuppressWarnings(
             "squid:S2068"
             // Credentials should not be hard-coded: 'password' detected
             // Justification: "password" is here the key to set the password in the connection parameters.
     )
-    static final String PROPERTY_PASSWORD_KEY = "password";
-    static final String PROPERTY_URL_KEY = "url";
-    static final String PROPERTY_HOST_KEY = "host";
-    static final String PROPERTY_PORT_KEY = "port";
-    static final String PROPERTY_DATABASE_KEY = "db";
+    public static final String PROPERTY_PASSWORD_KEY = "password";
+    public static final String PROPERTY_URL_KEY = "url";
+    public static final String PROPERTY_HOST_KEY = "host";
+    public static final String PROPERTY_PORT_KEY = "port";
+    public static final String PROPERTY_DATABASE_KEY = "db";
+    public static final String PROPERTY_SERIALIZATION = "serialization";
 
 
     static {
@@ -84,7 +94,7 @@ public class Driver extends UnregisteredDriver {
 
     @Override
     protected String getConnectStringPrefix() {
-        return URL_SCHEMA;
+        return DRIVER_URL_SCHEMA;
     }
 
 
@@ -113,12 +123,18 @@ public class Driver extends UnregisteredDriver {
         if ( metaFactory != null ) {
             service = metaFactory.create( connection );
         } else if ( config.url() != null ) {
-            // TODO: let the user chose between JSON and Google Protocol Buffers
-            //service = new RemoteService( getHttpClient( connection, config ) );
-            service = new RemoteProtobufService( getHttpClient( connection, config ), new ProtobufTranslationImpl() );
+            switch ( Serialization.valueOf( connection.config().serialization().toUpperCase() ) ) {
+                case JSON:
+                    service = new RemoteService( getHttpClient( connection, config ) );
+                    break;
+                case PROTOBUF:
+                    service = new RemoteProtobufService( getHttpClient( connection, config ), new ProtobufTranslationImpl() );
+                    break;
+                default:
+                    throw new RuntimeException( new IllegalArgumentException( "\"serialization\" is not one of " + Arrays.toString( Serialization.values() ) ) );
+            }
         } else {
             throw new RuntimeException( new NullPointerException( "config.url() == null" ) );
-            //service = new MockJsonService( Collections.<String, String>emptyMap() );
         }
         return service;
     }
@@ -242,13 +258,12 @@ public class Driver extends UnregisteredDriver {
                 }
 
                 if ( (parameterKey != null && parameterKey.length() > 0) && (parameterValue != null && parameterValue.length() > 0) ) {
+                    parameterKey = parameterKey.toLowerCase(); // our parameter keys are always lowercase
                     try {
-                        try {
-                            prop.setProperty( parameterKey, URLDecoder.decode( parameterValue, StandardCharsets.UTF_8.name() ) );
-                        } catch ( UnsupportedEncodingException e ) {
-                            // not going to happen - value came from JDK's own StandardCharsets
-                            throw new RuntimeException( e );
-                        }
+                        prop.setProperty( parameterKey, URLDecoder.decode( parameterValue, StandardCharsets.UTF_8.name() ) );
+                    } catch ( UnsupportedEncodingException e ) {
+                        // not going to happen - value came from JDK's own StandardCharsets
+                        throw new RuntimeException( e );
                     } catch ( NoSuchMethodError e ) {
                         log.debug( "Cannot use the decode method with UTF-8. Using the fallback (deprecated) method.", e );
                         //noinspection deprecation
@@ -325,19 +340,18 @@ public class Driver extends UnregisteredDriver {
         if ( colonPosition != -1 ) {
             host = hostPort.substring( 0, colonPosition );
 
-            if ( host.isEmpty() ) {
-                host = DEFAULT_HOST;
-            }
-
             if ( colonPosition + 1 < hostPort.length() ) {
                 port = hostPort.substring( colonPosition + 1 );
             }
         }
 
+        if ( host.isEmpty() ) {
+            host = DEFAULT_HOST;
+        }
+
         prop.setProperty( PROPERTY_HOST_KEY, host );
         prop.setProperty( PROPERTY_PORT_KEY, port );
-
-        prop.setProperty( PROPERTY_URL_KEY, (scheme.isEmpty() ? "http:" : scheme) + "//" + prop.getProperty( PROPERTY_HOST_KEY, DEFAULT_HOST ) + ":" + prop.getProperty( PROPERTY_PORT_KEY, Integer.toString( DEFAULT_PORT ) ) + "/" );
+        prop.setProperty( PROPERTY_URL_KEY, (scheme.isEmpty() ? DEFAULT_TRANSPORT_SCHEMA : scheme) + "//" + prop.getProperty( PROPERTY_HOST_KEY, DEFAULT_HOST ) + ":" + prop.getProperty( PROPERTY_PORT_KEY, Integer.toString( DEFAULT_PORT ) ) + "/" );
 
         // OVERRIDE URL BY DEFAULT
         if ( defaults != null ) {
@@ -346,6 +360,21 @@ public class Driver extends UnregisteredDriver {
                 final String value = defaults.getProperty( key );
                 prop.setProperty( key, value );
             }
+        }
+
+        // validate, fix, or set wire_protocol
+        switch ( prop.getProperty( PROPERTY_SERIALIZATION, DEFAULT_SERIALIZATION ).toUpperCase() ) {
+            case "JSON":
+                prop.setProperty( PROPERTY_SERIALIZATION, Serialization.JSON.name() );
+                break;
+            case "PROTOBUF":
+            case "PROTO":
+            case "PROTO3":
+                prop.setProperty( PROPERTY_SERIALIZATION, Serialization.PROTOBUF.name() );
+                break;
+            default:
+                prop.setProperty( PROPERTY_SERIALIZATION, prop.getProperty( PROPERTY_SERIALIZATION ).toUpperCase() );
+                break;
         }
 
         log.debug( "Result of parsing: {}", prop );

--- a/src/test/java/org/polypheny/jdbc/DriverTest.java
+++ b/src/test/java/org/polypheny/jdbc/DriverTest.java
@@ -304,7 +304,7 @@ public class DriverTest {
 
 
     @Test
-    public void parseUrl_String_Properties__AcceptableUrl_SetViaUrlParam() throws Exception {
+    public void parseUrl_String_null__AcceptableUrl_SetViaUrlParam() throws Exception {
         final Properties expected = new Properties();
         expected.setProperty( Driver.PROPERTY_USERNAME_KEY, "username" );
         expected.setProperty( Driver.PROPERTY_PASSWORD_KEY, "secret" );
@@ -317,6 +317,60 @@ public class DriverTest {
         expected.setProperty( Driver.PROPERTY_SERIALIZATION, Driver.DEFAULT_SERIALIZATION );
 
         final Properties actual = DRIVER.parseUrl( "jdbc:polypheny://username@localhost:20569/database?k1=v1&k2=v2&" + Driver.PROPERTY_PASSWORD_KEY + "=secret", null );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__DeprecatedParameterKeys() throws Exception {
+        final Properties expected = new Properties();
+        expected.setProperty( Driver.PROPERTY_HOST_KEY, Driver.DEFAULT_HOST );
+        expected.setProperty( Driver.PROPERTY_PORT_KEY, Integer.toString( Driver.DEFAULT_PORT ) );
+        expected.setProperty( Driver.PROPERTY_URL_KEY, Driver.DEFAULT_URL );
+
+        expected.setProperty( "wire_protocol", "wire_protocol" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, "WIRE_PROTOCOL" );
+
+        final Properties actual = DRIVER.parseUrl( "jdbc:polypheny:///?"
+                        + "wire_protocol=wire_protocol"
+                , null );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__DeprecatedParameterKeysOverwrite() throws Exception {
+        final Properties expected = new Properties();
+        expected.setProperty( Driver.PROPERTY_HOST_KEY, Driver.DEFAULT_HOST );
+        expected.setProperty( Driver.PROPERTY_PORT_KEY, Integer.toString( Driver.DEFAULT_PORT ) );
+        expected.setProperty( Driver.PROPERTY_URL_KEY, Driver.DEFAULT_URL );
+
+        expected.setProperty( "wire_protocol", "wire_protocol" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, "SERIALIZATION" );
+
+        final Properties actual = DRIVER.parseUrl( "jdbc:polypheny:///?"
+                        + "wire_protocol=wire_protocol" + "&" + "serialization=serialization"
+                , null );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__DeprecatedParameterKeysOverwrite2() throws Exception {
+        final Properties expected = new Properties();
+        expected.setProperty( Driver.PROPERTY_HOST_KEY, Driver.DEFAULT_HOST );
+        expected.setProperty( Driver.PROPERTY_PORT_KEY, Integer.toString( Driver.DEFAULT_PORT ) );
+        expected.setProperty( Driver.PROPERTY_URL_KEY, Driver.DEFAULT_URL );
+
+        expected.setProperty( "wire_protocol", "wire_protocol" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, "SERIALIZATION" );
+
+        final Properties actual = DRIVER.parseUrl( "jdbc:polypheny:///?"
+                        + "serialization=serialization" + "&" + "wire_protocol=wire_protocol"
+                , null );
 
         assertEquals( expected, actual );
     }

--- a/src/test/java/org/polypheny/jdbc/DriverTest.java
+++ b/src/test/java/org/polypheny/jdbc/DriverTest.java
@@ -20,8 +20,16 @@ package org.polypheny.jdbc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.Properties;
+import org.apache.calcite.avatica.remote.Driver.Serialization;
+import org.apache.calcite.avatica.remote.MockJsonService;
+import org.apache.calcite.avatica.remote.MockProtobufService;
+import org.apache.calcite.avatica.server.AvaticaJsonHandler;
+import org.apache.calcite.avatica.server.AvaticaProtobufHandler;
+import org.apache.calcite.avatica.server.HttpServer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -55,6 +63,15 @@ public class DriverTest {
 
     @After
     public void tearDown() {
+    }
+
+
+    @Test
+    public void acceptsURL_String__CorrectDriverSchema() throws Exception {
+        final boolean expected = true;
+        final boolean actual = DRIVER.acceptsURL( Driver.DRIVER_URL_SCHEMA );
+
+        assertEquals( expected, actual );
     }
 
 
@@ -165,6 +182,15 @@ public class DriverTest {
 
 
     @Test
+    public void acceptsURL_String__AcceptableUrlDefaultsOnly() throws Exception {
+        final boolean expected = true;
+        final boolean actual = DRIVER.acceptsURL( "jdbc:polypheny:///" );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
     public void acceptsURL_String__MalformedParameter() throws Exception {
         final boolean expected = true;
         final boolean actual = DRIVER.acceptsURL( "jdbc:polypheny://username:password@host:20569/database?k1=v1&k2" ); // k2 is ignored!
@@ -184,6 +210,7 @@ public class DriverTest {
         expected.setProperty( "k1", "v1" );
         expected.setProperty( "k2", "v2" );
         expected.setProperty( Driver.PROPERTY_URL_KEY, "http://localhost:20569/" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, Driver.DEFAULT_SERIALIZATION );
 
         final Properties actual = DRIVER.parseUrl( "jdbc:polypheny://username:password@localhost:20569/database?k1=v1&k2=v2", null );
 
@@ -197,6 +224,56 @@ public class DriverTest {
         final String actual = DRIVER
                 .parseUrl( "jdbc:polypheny://username:password@:20569/database?k1=v1&k2=v2", null )
                 .getProperty( Driver.PROPERTY_HOST_KEY );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__AcceptableUrl_AllDefaults() throws Exception {
+        final Properties expected = new Properties();
+        expected.setProperty( Driver.PROPERTY_HOST_KEY, Driver.DEFAULT_HOST );
+        expected.setProperty( Driver.PROPERTY_PORT_KEY, Integer.toString( Driver.DEFAULT_PORT ) );
+        expected.setProperty( Driver.PROPERTY_URL_KEY, Driver.DEFAULT_TRANSPORT_SCHEMA + "//" + Driver.DEFAULT_HOST + ":" + Driver.DEFAULT_PORT + "/" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, Driver.DEFAULT_SERIALIZATION );
+
+        final Properties actual = DRIVER.parseUrl( "jdbc:polypheny://", null );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__AcceptableUrl_AllDefaults_JsonWireProtocol() throws Exception {
+        final String expected = Serialization.JSON.name();
+        final String actual = DRIVER.parseUrl( "jdbc:polypheny://" + "?" + Driver.PROPERTY_SERIALIZATION + "=json", null ).getProperty( Driver.PROPERTY_SERIALIZATION );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__AcceptableUrl_AllDefaults_ProtobufWireProtocol() throws Exception {
+        final String expected = Serialization.PROTOBUF.name();
+        final String actual = DRIVER.parseUrl( "jdbc:polypheny://" + "?" + Driver.PROPERTY_SERIALIZATION + "=protobuf", null ).getProperty( Driver.PROPERTY_SERIALIZATION );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__AcceptableUrl_AllDefaults_ProtobufWireProtocol2() throws Exception {
+        final String expected = Serialization.PROTOBUF.name();
+        final String actual = DRIVER.parseUrl( "jdbc:polypheny://" + "?" + Driver.PROPERTY_SERIALIZATION + "=proto", null ).getProperty( Driver.PROPERTY_SERIALIZATION );
+
+        assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void parseUrl_String_null__AcceptableUrl_AllDefaults_ProtobufWireProtocol3() throws Exception {
+        final String expected = Serialization.PROTOBUF.name();
+        final String actual = DRIVER.parseUrl( "jdbc:polypheny://" + "?" + Driver.PROPERTY_SERIALIZATION + "=proto3", null ).getProperty( Driver.PROPERTY_SERIALIZATION );
 
         assertEquals( expected, actual );
     }
@@ -237,6 +314,7 @@ public class DriverTest {
         expected.setProperty( "k1", "v1" );
         expected.setProperty( "k2", "v2" );
         expected.setProperty( Driver.PROPERTY_URL_KEY, "http://localhost:20569/" );
+        expected.setProperty( Driver.PROPERTY_SERIALIZATION, Driver.DEFAULT_SERIALIZATION );
 
         final Properties actual = DRIVER.parseUrl( "jdbc:polypheny://username@localhost:20569/database?k1=v1&k2=v2&" + Driver.PROPERTY_PASSWORD_KEY + "=secret", null );
 
@@ -253,8 +331,8 @@ public class DriverTest {
 
     @Test
     public void connect_EmptyString_null() throws Exception {
-        final java.sql.Connection expected = null;
-        final java.sql.Connection actual = DRIVER.connect( "", null );
+        final Connection expected = null;
+        final Connection actual = DRIVER.connect( "", null );
 
         assertEquals( expected, actual );
     }
@@ -262,8 +340,8 @@ public class DriverTest {
 
     @Test
     public void connect_String_null__WrongSchema() throws Exception {
-        final java.sql.Connection expected = null;
-        final java.sql.Connection actual = DRIVER.connect( "foo:polypheny://username:password@localhost:20569/database?k1=v1&k2=v2", null );
+        final Connection expected = null;
+        final Connection actual = DRIVER.connect( "foo:polypheny://username:password@localhost:20569/database?k1=v1&k2=v2", null );
 
         assertEquals( expected, actual );
     }
@@ -271,9 +349,74 @@ public class DriverTest {
 
     @Test
     public void connect_String_null__WrongSubSchema() throws Exception {
-        final java.sql.Connection expected = null;
-        final java.sql.Connection actual = DRIVER.connect( "jdbc:foo://username:password@localhost:20569/database?k1=v1&k2=v2", null );
+        final Connection expected = null;
+        final Connection actual = DRIVER.connect( "jdbc:foo://username:password@localhost:20569/database?k1=v1&k2=v2", null );
 
         assertEquals( expected, actual );
+    }
+
+
+    @Test
+    public void connect_String_null__ProtobufWireProtocol() throws Exception {
+        final int port = Driver.DEFAULT_PORT;
+
+        HttpServer server = null;
+        try {
+            server = new HttpServer( port, new AvaticaProtobufHandler( new MockProtobufService( "" ) {
+                @Override
+                public Response _apply( Request request ) {
+                    if ( request instanceof OpenConnectionRequest ) {
+                        /*
+                         * The connectionId sent by the driver is randomly generated and cannot be known upfront, i.e., when the service is created.
+                         * Therefore, we have to intercept here.
+                         */
+                        return new OpenConnectionResponse();
+                    }
+                    return super._apply( request );
+                }
+            } ) );
+            server.start();
+
+            final Connection actual = DRIVER.connect( "jdbc:polypheny://localhost:" + port + "/?" + Driver.PROPERTY_SERIALIZATION + "=" + "protobuf", null );
+            actual.close();
+        } finally {
+            if ( server != null ) {
+                server.stop();
+            }
+        }
+    }
+
+
+    @Test
+    public void connect_String_null__JsonWireProtocol() throws Exception {
+        final int port = Driver.DEFAULT_PORT;
+
+        HttpServer server = null;
+        try {
+            server = new HttpServer( port, new AvaticaJsonHandler( new MockJsonService( Collections.emptyMap() ) {
+                @Override
+                public String apply( String request ) {
+                    /*
+                     * The connectionId sent by the driver is randomly generated and cannot be known upfront, i.e., when the service is created.
+                     * Therefore, we have to intercept here, check the requests and send responses back on our own
+                     */
+                    if ( request.startsWith( "{\"request\":\"openConnection\",\"connectionId\":\"" ) ) {
+                        return "{\"response\":\"openConnection\"}";
+                    }
+                    if ( request.startsWith( "{\"request\":\"closeConnection\",\"connectionId\":\"" ) ) {
+                        return "{\"response\":\"closeConnection\"}";
+                    }
+                    throw new RuntimeException( "No response for " + request );
+                }
+            } ) );
+            server.start();
+
+            final Connection actual = DRIVER.connect( "jdbc:polypheny://localhost:" + port + "/?" + Driver.PROPERTY_SERIALIZATION + "=" + "json", null );
+            actual.close();
+        } finally {
+            if ( server != null ) {
+                server.stop();
+            }
+        }
     }
 }


### PR DESCRIPTION
Clients can now choose the message serialization protocol.
The options are (i) Protobuf or (ii) JSON with Protobuf as default.

The new URL parameter / properties key "serialization" can be used to specify the protocol.
The value is not dependent on case, i.e., clients can specify, for example, "serialization=jSoN".

The former, not used, parameter key "wire_protocol" is deprecated and sets "serialization" if "serialization" is not present. (I.e., "wire_protocol" does not overwrite "serialization" if both are specified.)
