### PR TITLE
Handle connection reset

### DIFF
--- a/src/main/java/org/polypheny/jdbc/RpcService.java
+++ b/src/main/java/org/polypheny/jdbc/RpcService.java
@@ -18,6 +18,7 @@ package org.polypheny.jdbc;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -185,6 +186,10 @@ public class RpcService {
             callbackQueues.forEach( ( id, cq ) -> cq.onError( e ) );
             /* For Windows */
             if ( e.getMessage().contains( "An existing connection was forcibly closed by the remote host" ) && disconnectSent ) {
+                return;
+            }
+            /* For Windows */
+            if ( e instanceof SocketException && e.getMessage().contains( "Connection reset" ) && disconnectSent ) {
                 return;
             }
             // This will cause the exception to be thrown when the next call is made


### PR DESCRIPTION
When a `DisconnectRequest` is sent, the server sends a `DisconnectResponse` and closes the connection.  On Windows it can happen that the closing of the connection is reported via exception before the `DisconnectResponse` is processed.  There is already handling for the `An existing connection was forcibly closed by the remote host` case (just above the added lines), now add handling for `Connection reset` `SocketException` as well.