### PR TITLE
Standard fixes

### DIFF
--- a/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
+++ b/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
@@ -268,6 +268,7 @@ public class PolyphenyResultSet implements ResultSet {
 
 
     @Override
+    @Deprecated //according to jdbc 4.3
     public BigDecimal getBigDecimal( int columnIndex, int scale ) throws SQLException {
         throwIfClosed();
         return accessValue( columnIndex ).asBigDecimal( scale );
@@ -310,6 +311,7 @@ public class PolyphenyResultSet implements ResultSet {
 
 
     @Override
+    @Deprecated //according to jdbc 4.3
     public InputStream getUnicodeStream( int columnIndex ) throws SQLException {
         throwIfClosed();
         return accessValue( columnIndex ).asUnicodeStream();
@@ -372,6 +374,7 @@ public class PolyphenyResultSet implements ResultSet {
 
 
     @Override
+    @Deprecated //according to jdbc 4.3
     public BigDecimal getBigDecimal( String columnLabel, int scale ) throws SQLException {
         return getBigDecimal( metadata.getColumnIndexFromLabel( columnLabel ), scale );
     }
@@ -408,6 +411,7 @@ public class PolyphenyResultSet implements ResultSet {
 
 
     @Override
+    @Deprecated //according to jdbc 4.3
     public InputStream getUnicodeStream( String columnLabel ) throws SQLException {
         return getUnicodeStream( metadata.getColumnIndexFromLabel( columnLabel ) );
     }

--- a/src/main/java/org/polypheny/jdbc/types/TypedValue.java
+++ b/src/main/java/org/polypheny/jdbc/types/TypedValue.java
@@ -539,7 +539,37 @@ public class TypedValue implements Convertible {
         if ( isNull() ) {
             return null;
         }
-        throw new PrismInterfaceServiceException( PrismInterfaceErrors.DATA_TYPE_MISMATCH, "This value is not of type CHAR or VARCHAR." );
+        switch ( valueCase ) {
+            case BOOLEAN:
+                return booleanValue ? "1" : "0";
+            case INTEGER:
+                return integerValue.toString();
+            case LONG:
+                return bigintValue.toString();
+            case BIG_DECIMAL:
+                return bigDecimalValue.toString();
+            case FLOAT:
+                return floatValue.toString();
+            case DOUBLE:
+                return doubleValue.toString();
+            case DATE:
+                return dateValue.toString();
+            case TIME:
+                return timeValue.toString();
+            case TIMESTAMP:
+                return timestampValue.toString();
+            case INTERVAL:
+                return ((PolyInterval) otherValue).toString();
+            case BINARY:
+                return Arrays.toString( binaryValue );
+            case NULL:
+                return null;
+            case LIST:
+            case FILE:
+            case DOCUMENT:
+                throw new PrismInterfaceServiceException( PrismInterfaceErrors.DATA_TYPE_MISMATCH, "This value cannot be returned as a string." );
+        }
+        throw new PrismInterfaceServiceException( PrismInterfaceErrors.DATA_TYPE_MISMATCH, "This value cannot be returned as a string." );
     }
 
 
@@ -1427,6 +1457,49 @@ public class TypedValue implements Convertible {
 
     private static PolyInterval getInterval( ProtoInterval interval ) {
         return new PolyInterval( interval.getMonths(), interval.getMilliseconds() );
+    }
+
+
+    @Override
+    public String toString() {
+        if ( isSerialized ) {
+            deserialize();
+        }
+        switch ( valueCase ) {
+            case BOOLEAN:
+                return "" + booleanValue;
+            case INTEGER:
+                return "" + integerValue;
+            case LONG:
+                return "" + bigintValue;
+            case BIG_DECIMAL:
+                return "" + bigDecimalValue;
+            case FLOAT:
+                return "" + floatValue;
+            case DOUBLE:
+                return "" + doubleValue;
+            case DATE:
+                return "" + dateValue;
+            case TIME:
+                return "" + timeValue;
+            case TIMESTAMP:
+                return "" + timestampValue;
+            case INTERVAL:
+                return "" + otherValue;
+            case STRING:
+                return varcharValue;
+            case BINARY:
+                return "BINARY";
+            case NULL:
+                return "NULL";
+            case LIST:
+                return "LIST";
+            case FILE:
+                return "FILE";
+            case DOCUMENT:
+                return "DOCUMENT";
+        }
+        return "";
     }
 
 }

--- a/src/main/java/org/polypheny/jdbc/types/TypedValue.java
+++ b/src/main/java/org/polypheny/jdbc/types/TypedValue.java
@@ -216,6 +216,9 @@ public class TypedValue implements Convertible {
 
 
     public static TypedValue fromDate( Date dateValue, Calendar calendar ) {
+        if ( dateValue == null ) {
+            return fromNull();
+        }
         return fromDate( TypedValueUtils.getDateInCalendar( dateValue, calendar ) );
     }
 
@@ -1462,44 +1465,11 @@ public class TypedValue implements Convertible {
 
     @Override
     public String toString() {
-        if ( isSerialized ) {
-            deserialize();
+        try {
+            return asString();
+        } catch ( SQLException e ) {
+            throw new RuntimeException( e );
         }
-        switch ( valueCase ) {
-            case BOOLEAN:
-                return "" + booleanValue;
-            case INTEGER:
-                return "" + integerValue;
-            case LONG:
-                return "" + bigintValue;
-            case BIG_DECIMAL:
-                return "" + bigDecimalValue;
-            case FLOAT:
-                return "" + floatValue;
-            case DOUBLE:
-                return "" + doubleValue;
-            case DATE:
-                return "" + dateValue;
-            case TIME:
-                return "" + timeValue;
-            case TIMESTAMP:
-                return "" + timestampValue;
-            case INTERVAL:
-                return "" + otherValue;
-            case STRING:
-                return varcharValue;
-            case BINARY:
-                return "BINARY";
-            case NULL:
-                return "NULL";
-            case LIST:
-                return "LIST";
-            case FILE:
-                return "FILE";
-            case DOCUMENT:
-                return "DOCUMENT";
-        }
-        return "";
     }
 
 }

--- a/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
+++ b/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
@@ -45,6 +45,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.TimeZone;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.polypheny.jdbc.PrismInterfaceServiceException;
@@ -954,6 +955,94 @@ public class TypedValueTest {
         assertEquals( value.length(), typedValue2.getLength() );
     }
 
+    @Test
+    void testFromBoolean() throws SQLException {
+        TypedValue value = TypedValue.fromBoolean(true);
+        assertEquals("1", value.asString());
+    }
+
+    @Test
+    void testFromByte() throws SQLException {
+        byte byteValue = 10;
+        TypedValue value = TypedValue.fromByte(byteValue);
+        assertEquals("10", value.asString());
+    }
+
+    @Test
+    void testFromShort() throws SQLException {
+        short shortValue = 20;
+        TypedValue value = TypedValue.fromShort(shortValue);
+        assertEquals("20", value.asString());
+    }
+
+    @Test
+    void testFromInteger() throws SQLException {
+        int intValue = 30;
+        TypedValue value = TypedValue.fromInteger(intValue);
+        assertEquals("30", value.asString());
+    }
+
+    @Test
+    void testFromLong() throws SQLException {
+        long longValue = 40L;
+        TypedValue value = TypedValue.fromLong(longValue);
+        assertEquals("40", value.asString());
+    }
+
+    @Test
+    void testFromFloat() throws SQLException {
+        float floatValue = 50.5f;
+        TypedValue value = TypedValue.fromFloat(floatValue);
+        assertEquals("50.5", value.asString());
+    }
+
+    @Test
+    void testFromDouble() throws SQLException {
+        double doubleValue = 60.6;
+        TypedValue value = TypedValue.fromDouble(doubleValue);
+        assertEquals("60.6", value.asString());
+    }
+
+    @Test
+    void testFromBigDecimal() throws SQLException {
+        BigDecimal bigDecimalValue = new BigDecimal("70.7");
+        TypedValue value = TypedValue.fromBigDecimal(bigDecimalValue);
+        assertEquals("70.7", value.asString());
+    }
+
+    @Test
+    void testFromString() throws SQLException {
+        String stringValue = "test";
+        TypedValue value = TypedValue.fromString(stringValue);
+        assertEquals("test", value.asString());
+    }
+
+    @Test
+    void testFromDate() throws SQLException {
+        Date dateValue = new Date(2024, 7, 28);
+        TypedValue value = TypedValue.fromDate(dateValue);
+        assertEquals(dateValue.toString(), value.asString());
+    }
+
+    @Test
+    void testFromTime() throws SQLException {
+        Time timeValue = new Time(System.currentTimeMillis());
+        TypedValue value = TypedValue.fromTime(timeValue);
+        assertEquals(timeValue.toString(), value.asString());
+    }
+
+    @Test
+    void testFromTimestamp() throws SQLException {
+        Timestamp timestampValue = new Timestamp(System.currentTimeMillis());
+        TypedValue value = TypedValue.fromTimestamp(timestampValue);
+        assertEquals(timestampValue.toString(), value.asString());
+    }
 
 
+    @Test
+    void testFromInterval() throws SQLException {
+        PolyInterval interval = new PolyInterval(1, 0);
+        TypedValue value = TypedValue.fromInterval(interval);
+        assertEquals(interval.toString(), value.asString());
+    }
 }

--- a/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
+++ b/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
@@ -954,4 +954,6 @@ public class TypedValueTest {
         assertEquals( value.length(), typedValue2.getLength() );
     }
 
+
+
 }

--- a/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
+++ b/src/test/java/org/polypheny/jdbc/types/TypedValueTest.java
@@ -441,7 +441,8 @@ public class TypedValueTest {
         Calendar calendar = Calendar.getInstance();
         calendar.set( 2022, Calendar.JANUARY, 1 );
 
-        assertThrows( NullPointerException.class, () -> TypedValue.fromDate( null, calendar ) );
+        TypedValue value = TypedValue.fromDate( null, calendar );
+        assertTrue( value.isNull() );
     }
 
 


### PR DESCRIPTION
- Improved `toString` method to align with the standard-compliant `asString` implementation.
- Updated `fromDate` method to accept `null` as input when using a custom calendar, representing a missing value.