### PR TITLE
Add null check when closing result sets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ def protobufVersion = "3.23.4"
 
 dependencies {
     // Prism API files (protobuf files), needs to be implementation due to the prism-api-version.properties
-    implementation group: 'org.polypheny', name: 'prism', version: '1.9'
+    implementation group: 'org.polypheny', name: 'prism', version: '2.1'
 
     // Protobuf
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'signing'
-    id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
+    id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.9'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'io.freefair.lombok' version '8.7.1'
+    id 'io.freefair.lombok' version '8.11'
     id 'com.google.protobuf' version '0.9.4'
 }
 
@@ -61,14 +61,14 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
 
     // Apache Commons Lang
-    implementation group: "org.apache.commons", name: "commons-lang3", version: "3.16.0"
+    implementation group: "org.apache.commons", name: "commons-lang3", version: "3.17.0"
 
     // Logging
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16'
 
 
     // --- Test Compile ---
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.0'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.11.4'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
 }
 

--- a/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
+++ b/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
@@ -199,7 +199,9 @@ public class PolyphenyResultSet implements ResultSet {
         if ( isClosed ) {
             return;
         }
-        statement.notifyResultClosure();
+        if ( statement != null ) {
+            statement.notifyResultClosure();
+        }
         isClosed = true;
     }
 

--- a/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
+++ b/src/main/java/org/polypheny/jdbc/PolyphenyResultSet.java
@@ -53,7 +53,7 @@ public class PolyphenyResultSet implements ResultSet {
 
     private boolean isMeta = false;
 
-    private PolyphenyStatement statement;
+    private final PolyphenyStatement statement;
 
     private PolyphenyResultSetMetadata metadata;
     private Scrollable<List<TypedValue>> resultScroller;

--- a/src/test/java/org/polypheny/jdbc/StatementTest.java
+++ b/src/test/java/org/polypheny/jdbc/StatementTest.java
@@ -253,4 +253,10 @@ public class StatementTest {
         }
     }
 
+
+    @Test
+    void testCloseMetadataResultSet() throws SQLException {
+        con.getMetaData().getColumns( null, null, "t", null ).close();
+    }
+
 }


### PR DESCRIPTION
When a `PolyphenyResultSet` is created for a meta data result (such as a list of tables etc.) the `statement` field is set to `null`.  So check for `null` before trying to notify the non-existent statement.  Also add a test that would have exposed this issue.